### PR TITLE
Alter type definition for SolFormElement to include HTMLTextAreaElement

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,7 +2,10 @@ export type SolFormError<Values> = { [key in keyof Values]?: string };
 
 export type SolFormValidator<T> = (value: T) => string | void;
 
-export type SolFormElement = HTMLInputElement | HTMLSelectElement;
+export type SolFormElement =
+  | HTMLInputElement
+  | HTMLSelectElement
+  | HTMLTextAreaElement;
 
 export type SolFormValidatorsOption<Values> = {
   [key in keyof Partial<Values>]:


### PR DESCRIPTION
Typescript compiler currently throws an error while using solform with the textarea tag. This fix simply requires to change the type definition of the SolFormElement as the actual functionality does not change.