### PR TITLE
On submit focus on first failed input if validation fails. 

### DIFF
--- a/src/lib/createForm.ts
+++ b/src/lib/createForm.ts
@@ -8,7 +8,9 @@ import { SolFormElement, SolFormError, SolFormOptions } from "./types";
 
 const _setManuallyEvent = new CustomEvent("set-manually");
 
-export const createForm = <Values extends {}>(options: SolFormOptions<Values> = {}) => {
+export const createForm = <Values extends {}>(
+  options: SolFormOptions<Values> = {}
+) => {
   const refs: { [key in keyof Values]?: SolFormElement } = {};
   const [errors, setErrors] = createStore<SolFormError<Values>>({});
   const [loading, setLoading] = createSignal(false);
@@ -41,13 +43,17 @@ export const createForm = <Values extends {}>(options: SolFormOptions<Values> = 
       watchValue(refs[key]!, onChange, opts.callImmediately);
     });
 
-  const _validate = (formValues: Values) => validateForm(formValues, options.validators, setErrors);
+  const _validate = (formValues: Values) =>
+    validateForm(formValues, options.validators, setErrors, refs);
 
-  const getValue = <Key extends keyof Values, Value extends Values[Key]>(key: Key): Value =>
-    getValueTransformer(refs[key]!);
+  const getValue = <Key extends keyof Values, Value extends Values[Key]>(
+    key: Key
+  ): Value => getValueTransformer(refs[key]!);
 
-  const setValue = <Key extends keyof Values, Value extends Values[Key]>(key: Key, value: Value) =>
-    setValueTransformer(refs[key]!, value, _setManuallyEvent);
+  const setValue = <Key extends keyof Values, Value extends Values[Key]>(
+    key: Key,
+    value: Value
+  ) => setValueTransformer(refs[key]!, value, _setManuallyEvent);
 
   const submit = async (event?: Event | undefined) => {
     event?.preventDefault();
@@ -59,5 +65,14 @@ export const createForm = <Values extends {}>(options: SolFormOptions<Values> = 
     }
   };
 
-  return { register, submit, errors, getValue, setValue, loading, watch, getAllValues };
+  return {
+    register,
+    submit,
+    errors,
+    getValue,
+    setValue,
+    loading,
+    watch,
+    getAllValues,
+  };
 };

--- a/src/lib/modules/validateForm.ts
+++ b/src/lib/modules/validateForm.ts
@@ -1,22 +1,29 @@
 import { reconcile, SetStoreFunction } from "solid-js/store";
-import { SolFormError, SolFormValidatorsOption } from "../types";
+import {
+  SolFormError,
+  SolFormValidatorsOption,
+  SolFormElement,
+} from "../types";
 
 /** @internal */
 export const validateForm = <Values>(
   formValues: Values,
   validators: SolFormValidatorsOption<Values> | undefined,
-  setErrors: SetStoreFunction<SolFormError<Values>>
+  setErrors: SetStoreFunction<SolFormError<Values>>,
+  refs: { [key in keyof Values]?: SolFormElement }
 ) => {
   const validationErrors: any = {};
   if (!validators) {
     return true;
   }
+  let firstErrorKey: string | undefined;
   Object.entries(validators || {}).forEach(([key, validate]: [string, any]) => {
     if (Array.isArray(validate)) {
       for (let index = 0; index < validate.length; index++) {
         const _validator = validate[index];
         const result = _validator(formValues[key] ?? null);
         if (result) {
+          if (!firstErrorKey) firstErrorKey = key;
           validationErrors[key] = result;
           return;
         }
@@ -24,10 +31,14 @@ export const validateForm = <Values>(
     } else {
       const result = validate(formValues[key] ?? null);
       if (result) {
+        if (!firstErrorKey) firstErrorKey = key;
         validationErrors[key] = result;
       }
     }
   });
+
+  if (firstErrorKey) refs[firstErrorKey].focus();
+
   setErrors(reconcile(validationErrors));
   return Object.keys(validationErrors).length === 0;
 };


### PR DESCRIPTION
## On submit focus on first failed input if validation fails. 

When submitting the form, prioritize focusing on the first input that fails validation. However, please note that there is one caveat with this approach. Since validators are initialized when the form is created, it is possible that the inputs inside the JSX may become out of sync with the validators.

### What I mean by that is:
![image](https://github.com/ragokan/solform/assets/69647487/a8d965cb-eb2d-4278-a18f-b1ad34ef879f)

If you have validators in a specific order, it is important to ensure that the corresponding input fields are also arranged in the same order. Otherwise, wrong input field will be focused.

